### PR TITLE
Fix to_constraints/2 to match Firebird error messages

### DIFF
--- a/lib/ecto/adapters/firebird/connection.ex
+++ b/lib/ecto/adapters/firebird/connection.ex
@@ -78,64 +78,33 @@ defmodule Ecto.Adapters.Firebird.Connection do
     raise RuntimeError, "stream is not supported in the Firebird adapter"
   end
 
-  # we want to return the name of the underlying index that caused
-  # the constraint error, but in SQLite as far as I can tell there
-  # is no way to do this, so we name the index according to ecto
-  # convention, even if technically it _could_ have a different name
-  defp constraint_name_hack(constraint) do
-    if String.contains?(constraint, ", ") do
-      # "a.b, a.c" -> a_b_c_index
-      constraint
-      |> String.split(", ")
-      |> Enum.with_index()
-      |> Enum.map(fn
-        {table_col, 0} ->
-          String.replace(table_col, ".", "_")
-
-        {table_col, _} ->
-          table_col
-          |> String.split(".")
-          |> List.last()
-      end)
-      |> Enum.concat(["index"])
-      |> Enum.join("_")
-    else
-      constraint
-      |> String.split(".")
-      |> Enum.concat(["index"])
-      |> Enum.join("_")
-    end
-  end
+  # Firebird surfaces integrity violations as a `%Firebirdex.Error{}` whose
+  # `reason` carries the engine message (English, from firebird.msg) together
+  # with the real constraint name. We parse that message to build the keyword
+  # list Ecto expects. The name is matched by Ecto against the `:name` option
+  # of `unique_constraint/2`, `foreign_key_constraint/2` and
+  # `check_constraint/2`.
+  #
+  # Messages captured from Firebird 3:
+  #
+  #   unique/pk: violation of PRIMARY or UNIQUE KEY constraint "UQ_CODE" on table "T"
+  #   foreign:   violation of FOREIGN KEY constraint "FK_CHILD_PARENT" on table "T"
+  #   check:     Operation violates CHECK constraint CK_N on view or table T
+  #
+  # Note: UNIQUE/PRIMARY KEY and FOREIGN KEY share the same error `number`
+  # (335545072), so the message text is the only reliable discriminator.
+  @unique_key_re ~r/violation of PRIMARY or UNIQUE KEY constraint "([^"]+)"/
+  @foreign_key_re ~r/violation of FOREIGN KEY constraint "([^"]+)"/
+  @check_re ~r/Operation violates CHECK constraint (\S+) on/
 
   @impl true
-  def to_constraints(
-        %Firebirdex.Error{reason: "UNIQUE constraint failed: index " <> constraint},
-        _opts
-      ) do
-    # TODO: match error message
-    [unique: String.trim(constraint, ~s('))]
-  end
-
-  def to_constraints(
-        %Firebirdex.Error{reason: "UNIQUE constraint failed: " <> constraint},
-        _opts
-      ) do
-    # TODO: match error message
-    [unique: constraint_name_hack(constraint)]
-  end
-
-  def to_constraints(%Firebirdex.Error{reason: "FOREIGN KEY constraint failed"}, _opts) do
-    # TODO: match error message
-    # unfortunately we have no other date from Firebird
-    [foreign_key: nil]
-  end
-
-  def to_constraints(
-        %Firebirdex.Error{reason: "CHECK constraint failed: " <> name},
-        _opts
-      ) do
-    # TODO: match error message
-    [check: name]
+  def to_constraints(%Firebirdex.Error{reason: reason}, _opts) when is_binary(reason) do
+    cond do
+      match = Regex.run(@unique_key_re, reason) -> [unique: Enum.at(match, 1)]
+      match = Regex.run(@foreign_key_re, reason) -> [foreign_key: Enum.at(match, 1)]
+      match = Regex.run(@check_re, reason) -> [check: Enum.at(match, 1)]
+      true -> []
+    end
   end
 
   def to_constraints(_, _), do: []

--- a/test/ecto/adapters/firebird/connection_test.exs
+++ b/test/ecto/adapters/firebird/connection_test.exs
@@ -85,6 +85,74 @@ defmodule Ecto.Adapters.Firebird.ConnectionTest do
     IO.iodata_to_binary(SQL.delete(prefx, table, filter, returning))
   end
 
+  describe "to_constraints/2" do
+    # The `reason` strings below are the actual messages Firebird 3 returns
+    # (captured through firebirdex), not SQLite ones. UNIQUE/PRIMARY KEY and
+    # FOREIGN KEY share error number 335545072; CHECK uses 335544842.
+
+    test "unique key violation returns the constraint name" do
+      error = %Firebirdex.Error{
+        number: 335_545_072,
+        reason:
+          ~s|violation of PRIMARY or UNIQUE KEY constraint "UQ_ZZ_CODE" on table "ZZ_SCRATCH_UNIQ"\nProblematic key value is ("CODE" = 'A')\n|
+      }
+
+      assert SQL.to_constraints(error, []) == [unique: "UQ_ZZ_CODE"]
+    end
+
+    test "primary key violation is reported as a unique constraint" do
+      error = %Firebirdex.Error{
+        number: 335_545_072,
+        reason:
+          ~s|violation of PRIMARY or UNIQUE KEY constraint "INTEG_1923" on table "ZZ_SCRATCH_UNIQ"\nProblematic key value is ("ID" = 1)\n|
+      }
+
+      assert SQL.to_constraints(error, []) == [unique: "INTEG_1923"]
+    end
+
+    test "foreign key violation on insert returns the constraint name" do
+      error = %Firebirdex.Error{
+        number: 335_545_072,
+        reason:
+          ~s|violation of FOREIGN KEY constraint "FK_ZZ_CHILD_PARENT" on table "ZZ_SCRATCH_CHILD"\nForeign key reference target does not exist\nProblematic key value is ("PARENT_ID" = 999)\n|
+      }
+
+      assert SQL.to_constraints(error, []) == [foreign_key: "FK_ZZ_CHILD_PARENT"]
+    end
+
+    test "foreign key violation on delete returns the constraint name" do
+      error = %Firebirdex.Error{
+        number: 335_545_072,
+        reason:
+          ~s|violation of FOREIGN KEY constraint "FK_ZZ_CHILD_PARENT" on table "ZZ_SCRATCH_CHILD"\nForeign key references are present for the record\nProblematic key value is ("ID" = 1)\n|
+      }
+
+      assert SQL.to_constraints(error, []) == [foreign_key: "FK_ZZ_CHILD_PARENT"]
+    end
+
+    test "check constraint violation returns the constraint name" do
+      error = %Firebirdex.Error{
+        number: 335_544_842,
+        reason:
+          ~s|Operation violates CHECK constraint INTEG_1930 on view or table ZZ_SCRATCH_CHK\nAt trigger 'CHECK_9'\n|
+      }
+
+      assert SQL.to_constraints(error, []) == [check: "INTEG_1930"]
+    end
+
+    test "unrelated errors return no constraints" do
+      not_null = %Firebirdex.Error{
+        number: 335_544_347,
+        reason:
+          ~s|validation error for column "ZZ_SCRATCH_UNIQ"."ID", value "*** null ***"\n|
+      }
+
+      assert SQL.to_constraints(not_null, []) == []
+      assert SQL.to_constraints(%Firebirdex.Error{reason: "some other error"}, []) == []
+      assert SQL.to_constraints(%Firebirdex.Error{reason: nil}, []) == []
+    end
+  end
+
   test "from" do
     query = Schema |> select([r], r.x) |> plan()
     assert all(query) == ~s{SELECT s0."x" FROM "schema" AS s0}
@@ -2459,7 +2527,7 @@ defmodule Ecto.Adapters.Firebird.ConnectionTest do
   #
   #      error = %Firebirdex.Error{
   #        reason:
-  #          ~s("violation of PRIMARY or UNIQUE KEY constraint "email" on table "users")
+  #          ~s|"violation of PRIMARY or UNIQUE KEY constraint "email" on table "users"|
   #      }
   #
   #      assert Connection.to_constraints(error, []) == [unique: "users_email_index"]


### PR DESCRIPTION
## Motivation

`Ecto.Adapters.Firebird.Connection.to_constraints/2` was carried over from the SQLite adapter and still matches **SQLite** error strings:

```elixir
def to_constraints(%Firebirdex.Error{reason: "UNIQUE constraint failed: index " <> _}, _), do: ...
def to_constraints(%Firebirdex.Error{reason: "UNIQUE constraint failed: " <> _}, _), do: ...
def to_constraints(%Firebirdex.Error{reason: "FOREIGN KEY constraint failed"}, _), do: [foreign_key: nil]
def to_constraints(%Firebirdex.Error{reason: "CHECK constraint failed: " <> n}, _), do: [check: n]
def to_constraints(_, _), do: []
```

Firebird never emits those strings, so **every real integrity violation falls through to the catch-all and returns `[]`**. As a result `unique_constraint/2`, `foreign_key_constraint/2` and `check_constraint/2` are effectively no-ops against Firebird: instead of a changeset error the violation surfaces as an `Ecto.ConstraintError` (or the raw `%Firebirdex.Error{}`).

The actual messages Firebird 3 returns (captured through `firebirdex`) are:

| Violation | error `number` | `reason` |
|---|---|---|
| unique / primary key | `335545072` | `violation of PRIMARY or UNIQUE KEY constraint "NAME" on table "T"...` |
| foreign key (insert & delete) | `335545072` | `violation of FOREIGN KEY constraint "NAME" on table "T"...` |
| check | `335544842` | `Operation violates CHECK constraint NAME on view or table T...` |
| not null | `335544347` | `validation error for column "T"."C", value "*** null ***"` |

UNIQUE/PRIMARY KEY and FOREIGN KEY share the same `number` (`335545072`), so the message text is the only reliable discriminator.

## What changed

- `to_constraints/2` now matches the real engine messages with three module-level regexes and returns the actual constraint name that Ecto matches against the `:name` option of `unique_constraint/2` / `foreign_key_constraint/2` / `check_constraint/2`. Anything unrecognized still falls back to `[]`.
- Removed `constraint_name_hack/1`, a SQLite-only workaround that is no longer reachable.

```elixir
@unique_key_re ~r/violation of PRIMARY or UNIQUE KEY constraint "([^"]+)"/
@foreign_key_re ~r/violation of FOREIGN KEY constraint "([^"]+)"/
@check_re ~r/Operation violates CHECK constraint (\S+) on/

def to_constraints(%Firebirdex.Error{reason: reason}, _opts) when is_binary(reason) do
  cond do
    match = Regex.run(@unique_key_re, reason) -> [unique: Enum.at(match, 1)]
    match = Regex.run(@foreign_key_re, reason) -> [foreign_key: Enum.at(match, 1)]
    match = Regex.run(@check_re, reason) -> [check: Enum.at(match, 1)]
    true -> []
  end
end

def to_constraints(_, _), do: []
```

## Backwards compatibility

The removed clauses only matched SQLite strings Firebird never produces, so they were dead code — no working case relied on them. The catch-all still returns `[]` for anything unrecognized. The only observable change is that a real unique/foreign-key/check violation now yields the proper keyword list (previously always `[]`), which is what makes the `*_constraint/2` helpers work. Based on `master`.

## Testing

Added a `to_constraints/2` describe block in `connection_test.exs`. All assertions run against `to_constraints/2` with the messages captured above, so they need no server:

- unique key violation → `[unique: "..."]`
- primary key violation → reported as `[unique: "..."]`
- foreign key violation on insert → `[foreign_key: "..."]`
- foreign key violation on delete → `[foreign_key: "..."]`
- check violation → `[check: "..."]`
- unrelated errors (not-null / arbitrary / `nil` reason) → `[]`

```
6 tests, 0 failures
```

The other failures in the suite (`distinct`, `group by`, `fragments`, `interpolated values`) are pre-existing and unrelated to this change — they fail identically on `master` and come from a newer Ecto passing `Ecto.Query.ByExpr` where the adapter matches `Ecto.Query.QueryExpr`.
